### PR TITLE
fix(video-player): scroll to center

### DIFF
--- a/lib/widgets/media/flick_multi_player/portrait_controls.dart
+++ b/lib/widgets/media/flick_multi_player/portrait_controls.dart
@@ -56,7 +56,7 @@ class PortraitControls extends StatelessWidget {
                         bool isPlaying =
                             flickManager?.flickVideoManager?.isPlaying ?? false;
                         if (!isPlaying) {
-                          Scrollable.ensureVisible(context);
+                          Scrollable.ensureVisible(context, alignment: 0.5);
                         }
                         if (flickManager?.flickControlManager?.isMute ??
                             false) {


### PR DESCRIPTION
Fullscreen now scrolls video not visible to center of screen instead of scrolling to top